### PR TITLE
Update slack info & times on tutorials post

### DIFF
--- a/_posts/tutorial/2022-07-07-radiuss-on-aws.md
+++ b/_posts/tutorial/2022-07-07-radiuss-on-aws.md
@@ -17,10 +17,10 @@ Join us this summer as we host a series of tutorials in collaboration with AWS, 
 
 | Date | Time (Pacific) | Deadline to sign up | Project |
 | ---- | -------------- | ------------------- | ------- |
-| August 1–2, 2022 | 8:00 a.m. – 11:30 a.m. | July 25 | ![Spack logo]({{ site.baseurl }}/assets/img/small/llnl-spack.png) Learn to install your software quickly with [**Spack**](https://github.com/spack/spack) |
-| August 8, 2022 | 9:00 a.m. – 12:00 p.m. | August 1 | ![BLT logo]({{ site.baseurl }}/assets/img/small/llnl-blt.png) Build, link, and test large-scale applications with [**BLT**](https://github.com/LLNL/blt) |
-| August 10, 2022 | 9:00 a.m. – 12:00 p.m. | August 3 | ![Caliper logo]({{ site.baseurl }}/assets/img/small/llnl-caliper.png) Integrate performance profiling capabilities into your applications with [**Caliper**](https://github.com/LLNL/Caliper) |
-| August 15, 2022 | 9:00 a.m. – 12:00 p.m. | August 8 | ![MFEM logo]({{ site.baseurl }}/assets/img/small/llnl-mfem.png) Use [**MFEM**](https://github.com/mfem/mfem) for scalable finite element discretization application development |
-| August 17, 2022 | 9:00 a.m. – 12:00 p.m. | August 10 | ![Flux logo]({{ site.baseurl }}/assets/img/small/llnl-flux.png) Learn to run thousands of jobs in a workflow with [**Flux**](https://github.com/flux-framework/flux-core) |
-| Week of August 25, 2022 | 9:00 a.m. – 12:00 p.m. | August 18 | ![Ascent logo]({{ site.baseurl }}/assets/img/small/llnl-ascent.png) Visualize and analysis your simulations in situ with [**Ascent**](https://github.com/alpine-dav/ascent) |
-| August 25, 2022 | 9:00 a.m. – 12:00 p.m. | August 18 | ![RAJA logo]({{ site.baseurl }}/assets/img/small/llnl-raja.png) Use [**RAJA**](https://github.com/LLNL/RAJA) to run and port codes quickly across NVIDIA, AMD, and Intel GPUs |
+| August 1–2, 2022 | 8:00a.m.–11:30a.m. | July 25 | ![Spack logo]({{ site.baseurl }}/assets/img/small/llnl-spack.png) Learn to install your software quickly with [**Spack**](https://github.com/spack/spack) |
+| August 8, 2022 | 9:00a.m.–12:00p.m. | August 1 | ![BLT logo]({{ site.baseurl }}/assets/img/small/llnl-blt.png) Build, link, and test large-scale applications with [**BLT**](https://github.com/LLNL/blt) |
+| August 10, 2022 | 9:00a.m.–12:00p.m. | August 3 | ![Caliper logo]({{ site.baseurl }}/assets/img/small/llnl-caliper.png) Integrate performance profiling capabilities into your applications with [**Caliper**](https://github.com/LLNL/Caliper) |
+| August 15, 2022 | 9:00a.m.–12:00p.m. | August 8 | ![MFEM logo]({{ site.baseurl }}/assets/img/small/llnl-mfem.png) Use [**MFEM**](https://github.com/mfem/mfem) for scalable finite element discretization application development |
+| August 17, 2022 | 9:00a.m.–12:00p.m. | August 10 | ![Flux logo]({{ site.baseurl }}/assets/img/small/llnl-flux.png) Learn to run thousands of jobs in a workflow with [**Flux**](https://github.com/flux-framework/flux-core) |
+| Week of August 25, 2022 | 9:00a.m.–12:00p.m. | August 18 | ![Ascent logo]({{ site.baseurl }}/assets/img/small/llnl-ascent.png) Visualize and analysis your simulations in situ with [**Ascent**](https://github.com/alpine-dav/ascent) |
+| August 25, 2022 | 9:00a.m.–12:00p.m. | August 18 | ![RAJA logo]({{ site.baseurl }}/assets/img/small/llnl-raja.png) Use [**RAJA**](https://github.com/LLNL/RAJA) to run and port codes quickly across NVIDIA, AMD, and Intel GPUs |

--- a/_posts/tutorial/2022-07-07-radiuss-on-aws.md
+++ b/_posts/tutorial/2022-07-07-radiuss-on-aws.md
@@ -9,18 +9,18 @@ tags: [tutorial, event]
 
 Join us this summer as we host a series of tutorials in collaboration with AWS, demonstrating how to use several GPU-ready projects in the cloud and on premises. Follow along on your own EC2 instance (provided). No previous experience necessary.
 
-Collaborate with us on [**RADIUSS Slack**](https://radiuss-llnl.slack.com) and [**download the flier**]({{ site.baseurl }}/assets/posts/tutorial/2022-07-07-radiuss-on-aws/RADIUSS_tutorials_flier_final.pdf) (127 KB PDF) to share with your colleagues. Feel free to [**email us**](mailto:radiuss-outreach@llnl.gov) with any questions.
+[**Download the flier**]({{ site.baseurl }}/assets/posts/tutorial/2022-07-07-radiuss-on-aws/RADIUSS_tutorials_flier_final.pdf) (127 KB PDF) to share with your colleagues. Feel free to [**email us**](mailto:radiuss-outreach@llnl.gov) with any questions. We'll add all registrants to the RADIUSS Slack channel.
 
 ## We're offering seven tutorials in August
 
 <a class="btn btn-dark btn-lg" type="button" href="https://forms.gle/3wAKK5PBizUiNaVg6" alt="Sign up button" target="_blank">Sign up today</a>
 
-| Date | Deadline to sign up | Project |
-| ---- | ------------------- | ------- |
-| Week of August 1, 2022 | July 25 | ![Spack logo]({{ site.baseurl }}/assets/img/small/llnl-spack.png) Learn to install your software quickly with [**Spack**](https://github.com/spack/spack) |
-| August 8, 2022 | August 1 | ![BLT logo]({{ site.baseurl }}/assets/img/small/llnl-blt.png) Build, link, and test large-scale applications with [**BLT**](https://github.com/LLNL/blt) |
-| August 10, 2022 | August 3 | ![Caliper logo]({{ site.baseurl }}/assets/img/small/llnl-caliper.png) Integrate performance profiling capabilities into your applications with [**Caliper**](https://github.com/LLNL/Caliper) |
-| August 15, 2022 | August 8 | ![MFEM logo]({{ site.baseurl }}/assets/img/small/llnl-mfem.png) Use [**MFEM**](https://github.com/mfem/mfem) for scalable finite element discretization application development |
-| August 17, 2022 | August 10 | ![Flux logo]({{ site.baseurl }}/assets/img/small/llnl-flux.png) Learn to run thousands of jobs in a workflow with [**Flux**](https://github.com/flux-framework/flux-core) |
-| Week of August 25, 2022 | August 18 | ![Ascent logo]({{ site.baseurl }}/assets/img/small/llnl-ascent.png) Visualize and analysis your simulations in situ with [**Ascent**](https://github.com/alpine-dav/ascent) |
-| August 25, 2022 | August 18 | ![RAJA logo]({{ site.baseurl }}/assets/img/small/llnl-raja.png) Use [**RAJA**](https://github.com/LLNL/RAJA) to run and port codes quickly across NVIDIA, AMD, and Intel GPUs |
+| Date | Time (Pacific) | Deadline to sign up | Project |
+| ---- | -------------- | ------------------- | ------- |
+| August 1–2, 2022 | 8:00 a.m. – 11:30 a.m. | July 25 | ![Spack logo]({{ site.baseurl }}/assets/img/small/llnl-spack.png) Learn to install your software quickly with [**Spack**](https://github.com/spack/spack) |
+| August 8, 2022 | 9:00 a.m. – 12:00 p.m. | August 1 | ![BLT logo]({{ site.baseurl }}/assets/img/small/llnl-blt.png) Build, link, and test large-scale applications with [**BLT**](https://github.com/LLNL/blt) |
+| August 10, 2022 | 9:00 a.m. – 12:00 p.m. | August 3 | ![Caliper logo]({{ site.baseurl }}/assets/img/small/llnl-caliper.png) Integrate performance profiling capabilities into your applications with [**Caliper**](https://github.com/LLNL/Caliper) |
+| August 15, 2022 | 9:00 a.m. – 12:00 p.m. | August 8 | ![MFEM logo]({{ site.baseurl }}/assets/img/small/llnl-mfem.png) Use [**MFEM**](https://github.com/mfem/mfem) for scalable finite element discretization application development |
+| August 17, 2022 | 9:00 a.m. – 12:00 p.m. | August 10 | ![Flux logo]({{ site.baseurl }}/assets/img/small/llnl-flux.png) Learn to run thousands of jobs in a workflow with [**Flux**](https://github.com/flux-framework/flux-core) |
+| Week of August 25, 2022 | 9:00 a.m. – 12:00 p.m. | August 18 | ![Ascent logo]({{ site.baseurl }}/assets/img/small/llnl-ascent.png) Visualize and analysis your simulations in situ with [**Ascent**](https://github.com/alpine-dav/ascent) |
+| August 25, 2022 | 9:00 a.m. – 12:00 p.m. | August 18 | ![RAJA logo]({{ site.baseurl }}/assets/img/small/llnl-raja.png) Use [**RAJA**](https://github.com/LLNL/RAJA) to run and port codes quickly across NVIDIA, AMD, and Intel GPUs |


### PR DESCRIPTION
Added specific blocks of time for each tutorial. Removed Slack link since we'll be adding people after they register.