### PR TITLE
Meta descriptions and page titles for federal compliance

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -10,7 +10,7 @@
   {% else %}<meta property="og:type" content="website">{% endif %}
 
   <meta property="og:url" content="{{ site.domain }}{{ site.baseurl }}{{ page.url }}">
-  <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
+  <meta property="og:title" content="{{ site.title }} | {% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
   <meta property="og:image" content="{% if page.image %}{{ site.domain }}{{ site.baseurl }}{{ page.image }}{% else %}{{ site.domain }}{{ site.baseurl }}{{ site.twitter-img }}{% endif %}">
   <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
   <meta property="og:site_name" content="{{ site.title }}">
@@ -24,7 +24,7 @@
   {% if page.image %}<meta name="twitter:image" content="{{ site.domain }}{{ site.baseurl }}{{ page.image }}">{% else %}<meta name="twitter:image" content="{{ site.domain }}{{ site.baseurl }}{{ site.twitter-img }}">{% endif %}
 
   <!-- Social: Google+ / Schema.org  -->
-  <meta itemprop="name" content="{{ page.title }}">
+  <meta itemprop="name" content="{{ site.title }} | {{ page.title }}">
   <meta itemprop="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
   <meta itemprop="image" content="{% if page.image %}{{ site.domain }}{{ site.baseurl }}{{ page.image }}{% else %}{{ site.domain }}{{ site.baseurl }}{{ site.twitter-img }}{% endif %}">
   <script type="application/ld+json">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>{{ site.title }}</title>
-  <meta name="description" content="{{ site.description }}">
+  <title>{{ site.title }} | {{ page.title }}</title>
+  <meta name="description" content="{{ page.description }}">
   {% include meta.html %}
 
   <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0/css/bootstrap.css'>

--- a/_posts/developer-survey/2023-02-08-first-developer-survey.md
+++ b/_posts/developer-survey/2023-02-08-first-developer-survey.md
@@ -3,6 +3,7 @@ title: "Results from the 1st LLNL Developer Survey, 2022"
 date: 2023-02-08"
 draft: false
 layout: post
+description: A summary of results from the 2022 survey of LLNL developers' practices and preferences.
 ---
 
 > Author Vanessa Sochat, on behalf of the RADIUSS team

--- a/_posts/tutorial/2022-07-07-radiuss-on-aws.md
+++ b/_posts/tutorial/2022-07-07-radiuss-on-aws.md
@@ -1,8 +1,9 @@
 ---
-layout: post
 title: "RADIUSS AWS Tutorials: August 2022"
 category: event
 tags: [tutorial, event]
+layout: post
+description: Details about the 2022 tutorial series including registration, documentation, and other materials.
 ---
 
 ## Learn how to use a modern HPC software stack

--- a/_posts/tutorial/2023-07-11-radiuss-on-aws.md
+++ b/_posts/tutorial/2023-07-11-radiuss-on-aws.md
@@ -1,8 +1,9 @@
 ---
-layout: post
 title: "RADIUSS AWS Tutorials: August 2023"
 category: event
 tags: [tutorial, event]
+layout: post
+description: Details about the 2023 tutorial series including registration, documentation, and other materials.
 ---
 
 ## Learn how to use a modern HPC software stack

--- a/news/index.html
+++ b/news/index.html
@@ -1,5 +1,6 @@
 ---
 layout: news
+description: News from RADIUSS teams and updates about events and other activities.
 title: News and Updates
 menubar: news
 no_footer: true

--- a/pages/about.md
+++ b/pages/about.md
@@ -1,5 +1,6 @@
 ---
 layout: page
+description: Information about RADIUSS mission, products, and DevOps.
 title: About
 permalink: /about/
 graph: true

--- a/pages/index.md
+++ b/pages/index.md
@@ -1,5 +1,6 @@
 ---
 layout: home
+description: RADIUSS aims to develop and deploy a common base of foundational scientific software with opt-in adoption from LLNL applications in order to reduce long-term software costs and increase agility.
 permalink: /
 ---
 

--- a/pages/opensource-heartbeat/archive/create.md
+++ b/pages/opensource-heartbeat/archive/create.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-archive
+description: Archive of project creation activity.
 title: Create Events Archive
 event_type: CreateEvent
 permalink: activity/archive/createevent/

--- a/pages/opensource-heartbeat/archive/issuecomment.md
+++ b/pages/opensource-heartbeat/archive/issuecomment.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-archive
+description: Archive of issue comments activity.
 title: Issue Comment Events Archive
 event_type: IssueCommentEvent
 permalink: activity/archive/issuecommentevent/

--- a/pages/opensource-heartbeat/archive/issues.md
+++ b/pages/opensource-heartbeat/archive/issues.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-archive
+description: Archive of issues activity.
 title: Issues Events Archive
 event_type: IssuesEvent
 permalink: activity/archive/issuesevent/

--- a/pages/opensource-heartbeat/archive/public.md
+++ b/pages/opensource-heartbeat/archive/public.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-archive
+description: Archive of public events activity.
 title: Public Event Archive
 event_type: PublicEvent
 permalink: activity/archive/publicevent/

--- a/pages/opensource-heartbeat/archive/pullrequest.md
+++ b/pages/opensource-heartbeat/archive/pullrequest.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-archive
+description: Archive of pull request activity.
 title: Pull Request Events Archive
 event_type: PullRequestEvent
 permalink: activity/archive/pullrequestevent/

--- a/pages/opensource-heartbeat/archive/pullrequestreview.md
+++ b/pages/opensource-heartbeat/archive/pullrequestreview.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-archive
+description: Archive of pull request review activity.
 title: Pull Request Review Events Archive
 event_type: PullRequestReviewEvent
 permalink: activity/archive/pullrequestreviewevent/

--- a/pages/opensource-heartbeat/archive/pullrequestreviewcomment.md
+++ b/pages/opensource-heartbeat/archive/pullrequestreviewcomment.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-archive
+description: Archive of pull request comments activity.
 title: Pull Request Review Comment Event Archive
 event_type: PullRequestReviewCommentEvent
 permalink: activity/archive/pullrequestreviewcommentevent/

--- a/pages/opensource-heartbeat/archive/push.md
+++ b/pages/opensource-heartbeat/archive/push.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-archive
+description: Archive of push activity such as commits.
 title: Push Events Archive
 event_type: PushEvent
 permalink: activity/archive/pushevent/

--- a/pages/opensource-heartbeat/archive/release.md
+++ b/pages/opensource-heartbeat/archive/release.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-archive
+description: Archive of release events activity.
 title: Release Events Archive
 event_type: ReleaseEvent
 permalink: activity/archive/releaseevent/

--- a/pages/opensource-heartbeat/browse/create.md
+++ b/pages/opensource-heartbeat/browse/create.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-page
+description: Project activity by repo creation.
 title: Create Events
 event_type: CreateEvent
 permalink: activity/createevent/

--- a/pages/opensource-heartbeat/browse/issuecomment.md
+++ b/pages/opensource-heartbeat/browse/issuecomment.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-page
+description: Project activity by issue comment.
 title: Issue Comment Events
 event_type: IssueCommentEvent
 permalink: activity/issuecommentevent/

--- a/pages/opensource-heartbeat/browse/issues.md
+++ b/pages/opensource-heartbeat/browse/issues.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-page
+description: Project activity by issues.
 title: Issues Events
 event_type: IssuesEvent
 permalink: activity/issuesevent/

--- a/pages/opensource-heartbeat/browse/public.md
+++ b/pages/opensource-heartbeat/browse/public.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-page
+description: Project activity by public events.
 title: Public Event
 event_type: PublicEvent
 permalink: activity/publicevent/

--- a/pages/opensource-heartbeat/browse/pullrequest.md
+++ b/pages/opensource-heartbeat/browse/pullrequest.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-page
+description: Project activity by pull requests.
 title: Pull Request Events
 event_type: PullRequestEvent
 permalink: activity/pullrequestevent/

--- a/pages/opensource-heartbeat/browse/pullrequestreview.md
+++ b/pages/opensource-heartbeat/browse/pullrequestreview.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-page
+description: Project activity by pull request reviews.
 title: Pull Request Review Events
 event_type: PullRequestReviewEvent
 permalink: activity/pullrequestreviewevent/

--- a/pages/opensource-heartbeat/browse/pullrequestreviewcomment.md
+++ b/pages/opensource-heartbeat/browse/pullrequestreviewcomment.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-page
+description: Project activity by pull request reviews comments.
 title: Pull Request Review Comment Event
 event_type: PullRequestReviewCommentEvent
 permalink: activity/pullrequestreviewcommentevent/

--- a/pages/opensource-heartbeat/browse/push.md
+++ b/pages/opensource-heartbeat/browse/push.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-page
+description: Project activity by push events.
 title: Push Events
 event_type: PushEvent
 permalink: activity/pushevent/

--- a/pages/opensource-heartbeat/browse/release.md
+++ b/pages/opensource-heartbeat/browse/release.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-page
+description: Project activity by latest releases.
 title: Release Events
 event_type: ReleaseEvent
 permalink: activity/releaseevent/

--- a/pages/opensource-heartbeat/chart.md
+++ b/pages/opensource-heartbeat/chart.md
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-chart
+description: Graph showing project activity by types of contributions.
 permalink: /activity/chart
 title: Contribution Graph
 excluded_in_search: true

--- a/pages/opensource-heartbeat/index.md
+++ b/pages/opensource-heartbeat/index.md
@@ -1,5 +1,7 @@
 ---
+title: Open Source Heartbeat
 layout: heartbeat-home
+description: Project activities by filterable categories.
 permalink: /activity/
 excluded_in_search: true
 ---

--- a/pages/opensource-heartbeat/search.html
+++ b/pages/opensource-heartbeat/search.html
@@ -1,5 +1,6 @@
 ---
 layout: heartbeat-default
+description: Search the dynamic catalog of RADIUSS projects.
 title: Search
 sitemap: false
 permalink: /activity/search

--- a/pages/projects.md
+++ b/pages/projects.md
@@ -1,5 +1,6 @@
 ---
 layout: projects
+description: Searchable catalog of RADIUSS projects, also known as products.
 title: Projects
 permalink: /projects/
 hide_hero: true

--- a/pages/tags.html
+++ b/pages/tags.html
@@ -1,5 +1,6 @@
 ---
 layout: page
+description: Tags associated with RADIUSS projects that make dynamic filtering work on this site.
 title: "Tag Index"
 permalink: /tags/
 no_footer: true


### PR DESCRIPTION
https://standards.digital.gov/standards/
Updates to page titles (uniqueness) and meta descriptions (added to most pages) to meet these requirements due on 9/26 for sites on the llnl.gov domain. A side effect is that the description now shows up on About and News—the only two pages where this seems to happen—and I was unable to squash it. It's not terrible UX, though, to display the description.